### PR TITLE
Issue #59: ChatWindowView hidden behind the android status bar and keyboard

### DIFF
--- a/inappchat/src/main/java/com/livechatinc/inappchat/ChatWindowView.java
+++ b/inappchat/src/main/java/com/livechatinc/inappchat/ChatWindowView.java
@@ -76,7 +76,7 @@ public class ChatWindowView extends FrameLayout implements IChatWindowView {
      * ChatWindowView is hidden until it is initialized and shown.
      */
     public static ChatWindowView createAndAttachChatWindowInstance(@NonNull Activity activity) {
-        final ViewGroup contentView = (ViewGroup) activity.getWindow().getDecorView().findViewById(android.R.id.content);
+        final ViewGroup contentView = ((ViewGroup) ((ViewGroup) activity.getWindow().findViewById(android.R.id.content)).getChildAt(0));
         ChatWindowView chatWindowView = (ChatWindowView) LayoutInflater.from(activity).inflate(R.layout.view_chat_window, contentView, false);
         contentView.addView(chatWindowView, WindowManager.LayoutParams.MATCH_PARENT, WindowManager.LayoutParams.MATCH_PARENT);
         return chatWindowView;


### PR DESCRIPTION
fix for https://github.com/livechat/chat-window-android/issues/59 top of livechat being hidden behind the android status bar and text input hidden by keyboard, see https://stackoverflow.com/a/5069354
this impacts many Samsung devices Galaxy S8, S9 etc.
