### PR TITLE
Fix dropdown menu support in prechat form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Android ChangeLog
 
+## Version 3.0.3
+
+* Fix dropdown menu not working with AppScope LiveChatView integration #112
+
+**Breaking Change**
+Custom integration - directly using `LiveChatView`, with `LiveChatViewLifecycleScope.APP` in an Activity or Fragment, now requires to also detach context using `LiveChatView.detachFrom()` during `onDestroy` lifecycle event
+
 ## Version 3.0.1
 
 * Use `okhttp` client engine by default, instead of `cio`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,7 @@
 
 ## Version 3.0.3
 
-* Fix dropdown menu not working with AppScope LiveChatView integration #112
-
-**Breaking Change**
-Custom integration - directly using `LiveChatView`, with `LiveChatViewLifecycleScope.APP` in an Activity or Fragment, now requires to also detach context using `LiveChatView.detachFrom()` during `onDestroy` lifecycle event
+* Fix dropdown menus not showing in `LiveChatViewLifecycleScope.APP` mode #112
 
 ## Version 3.0.1
 

--- a/README.md
+++ b/README.md
@@ -221,12 +221,6 @@ During `onCreate` of your `Activity` or `Fragment`, call:
 liveChatView.attachTo(this)
 ```
 
-and detach context in `onDestroy`:
-
-```kotlin
-liveChatView.detachFrom(this)
-```
-
 This is required to properly handle the view's lifecycle, support file sharing, and launch links in the default external browser.
 
 ### 3. React to visibility events

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Next, add dependency to your app's `build.gradle`:
 
 ```kotlin
 dependencies {
-    implementation 'com.github.livechat:chat-window-android:3.0.2'
+    implementation 'com.github.livechat:chat-window-android:3.0.3'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,12 @@ During `onCreate` of your `Activity` or `Fragment`, call:
 liveChatView.attachTo(this)
 ```
 
+and detach context in `onDestroy`:
+
+```kotlin
+liveChatView.detachFrom(this)
+```
+
 This is required to properly handle the view's lifecycle, support file sharing, and launch links in the default external browser.
 
 ### 3. React to visibility events

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,7 +71,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.12.0'
     implementation 'com.google.code.gson:gson:2.8.9'
-    implementation 'com.github.livechat:chat-window-android:3.0.1'
+    implementation 'com.github.livechat:chat-window-android:3.0.3-rc1'
     implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
     implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.9.1'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.9.1'

--- a/chat-sdk/src/main/java/com/livechatinc/chatsdk/LiveChat.kt
+++ b/chat-sdk/src/main/java/com/livechatinc/chatsdk/LiveChat.kt
@@ -128,7 +128,7 @@ class LiveChat private constructor(
     }
 
     /**
-     * Should be used with [LiveChatViewLifecycleScope.APP] scope
+     * Should be used only with [LiveChatViewLifecycleScope.APP] scope
      * Creates [LiveChatView] instance or returns existing one
      * */
     fun getLiveChatView(): LiveChatView {
@@ -136,7 +136,7 @@ class LiveChat private constructor(
     }
 
     /**
-     * Should be used with [LiveChatViewLifecycleScope.APP] scope
+     * Should be used only with [LiveChatViewLifecycleScope.APP] scope
      * Removes [LiveChatView] from parent and destroys it
      * */
     fun destroyLiveChatView() {

--- a/chat-sdk/src/main/java/com/livechatinc/chatsdk/src/core/managers/AppScopedLiveChatViewManagerImpl.kt
+++ b/chat-sdk/src/main/java/com/livechatinc/chatsdk/src/core/managers/AppScopedLiveChatViewManagerImpl.kt
@@ -1,6 +1,7 @@
 package com.livechatinc.chatsdk.src.core.managers
 
 import android.content.Context
+import android.content.MutableContextWrapper
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
@@ -12,7 +13,7 @@ internal class AppScopedLiveChatViewManagerImpl(private val applicationContext: 
     private var liveChatView: LiveChatView? = null
 
     override fun getLiveChatView(): LiveChatView {
-        return liveChatView ?: inflate(applicationContext).also {
+        return liveChatView ?: inflate(MutableContextWrapper(applicationContext)).also {
             liveChatView = it
         }
     }

--- a/chat-sdk/src/main/java/com/livechatinc/chatsdk/src/presentation/LiveChatActivity.kt
+++ b/chat-sdk/src/main/java/com/livechatinc/chatsdk/src/presentation/LiveChatActivity.kt
@@ -100,7 +100,6 @@ class LiveChatActivity : AppCompatActivity() {
 
     override fun onDestroy() {
         if (LiveChat.getInstance().liveChatViewLifecycleScope == LiveChatViewLifecycleScope.APP) {
-            liveChatView.detachFrom(this)
             liveChatView.clearCallbackListeners()
             container.removeView(liveChatView)
         }

--- a/chat-sdk/src/main/java/com/livechatinc/chatsdk/src/presentation/LiveChatActivity.kt
+++ b/chat-sdk/src/main/java/com/livechatinc/chatsdk/src/presentation/LiveChatActivity.kt
@@ -100,6 +100,7 @@ class LiveChatActivity : AppCompatActivity() {
 
     override fun onDestroy() {
         if (LiveChat.getInstance().liveChatViewLifecycleScope == LiveChatViewLifecycleScope.APP) {
+            liveChatView.detachFrom(this)
             liveChatView.clearCallbackListeners()
             container.removeView(liveChatView)
         }

--- a/chat-sdk/src/main/java/com/livechatinc/chatsdk/src/presentation/LiveChatView.kt
+++ b/chat-sdk/src/main/java/com/livechatinc/chatsdk/src/presentation/LiveChatView.kt
@@ -103,7 +103,7 @@ class LiveChatView(
 
         activityContextRef = WeakReference(activity)
         currentLifecycleOwner = fragment
-        activity.lifecycle.addObserver(this)
+        fragment.lifecycle.addObserver(this)
 
         setupFileSharing(activity, fragment.lifecycle)
         setWebViewBackgroundColor(fragment.requireContext())
@@ -117,10 +117,6 @@ class LiveChatView(
         if (webViewContext is MutableContextWrapper) {
             webViewContext.baseContext = context
         }
-    }
-
-    fun detachFrom(activity: ComponentActivity) {
-        updateWebViewContext(activity.applicationContext)
     }
 
     private fun detachCurrentLifecycleOwner() {
@@ -228,6 +224,7 @@ class LiveChatView(
         if (owner == currentLifecycleOwner) {
             detachCurrentLifecycleOwner()
         }
+        updateWebViewContext(context.applicationContext)
 
         super.onStop(owner)
     }

--- a/chat-sdk/src/main/java/com/livechatinc/chatsdk/src/presentation/LiveChatView.kt
+++ b/chat-sdk/src/main/java/com/livechatinc/chatsdk/src/presentation/LiveChatView.kt
@@ -3,6 +3,7 @@ package com.livechatinc.chatsdk.src.presentation
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
+import android.content.MutableContextWrapper
 import android.graphics.Color
 import android.net.Uri
 import android.os.Bundle
@@ -20,15 +21,14 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import com.livechatinc.chatsdk.LiveChat
 import com.livechatinc.chatsdk.src.core.LiveChatViewLifecycleScope
-import com.livechatinc.chatsdk.R
-import com.livechatinc.chatsdk.src.utils.webview.LiveChatViewChromeClient
-import com.livechatinc.chatsdk.src.utils.webview.LiveChatViewJSBridge
-import com.livechatinc.chatsdk.src.domain.presenters.LiveChatViewPresenter
 import com.livechatinc.chatsdk.src.domain.interfaces.LiveChatViewInternal
-import com.livechatinc.chatsdk.src.utils.webview.LiveChatViewWebViewClient
+import com.livechatinc.chatsdk.src.domain.models.FilePickerMode
+import com.livechatinc.chatsdk.src.domain.presenters.LiveChatViewPresenter
 import com.livechatinc.chatsdk.src.utils.FileSharing
 import com.livechatinc.chatsdk.src.utils.Logger
-import com.livechatinc.chatsdk.src.domain.models.FilePickerMode
+import com.livechatinc.chatsdk.src.utils.webview.LiveChatViewChromeClient
+import com.livechatinc.chatsdk.src.utils.webview.LiveChatViewJSBridge
+import com.livechatinc.chatsdk.src.utils.webview.LiveChatViewWebViewClient
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -40,14 +40,13 @@ class LiveChatView(
     attrs: AttributeSet?
 ) : FrameLayout(context, attrs), LiveChatViewInternal, DefaultLifecycleObserver {
     private var fileSharing: FileSharing? = null
-    private var webView: WebView
+    private var webView: WebView = WebView(context, attrs)
     private var presenter: LiveChatViewPresenter
     private var activityContextRef: WeakReference<Context>? = null
     private var currentLifecycleOwner: LifecycleOwner? = null
 
     init {
-        inflate(context, R.layout.live_chat_widget_internal, this)
-        webView = findViewById(R.id.live_chat_webview)
+        this.addView(webView)
         presenter = LiveChatViewPresenter(this, LiveChat.getInstance().networkClient)
 
         configureWebView()
@@ -87,6 +86,8 @@ class LiveChatView(
 
         setupFileSharing(activity, activity.lifecycle)
         setWebViewBackgroundColor(activity)
+
+        updateWebViewContext(activity)
     }
 
     /**
@@ -106,6 +107,20 @@ class LiveChatView(
 
         setupFileSharing(activity, fragment.lifecycle)
         setWebViewBackgroundColor(fragment.requireContext())
+
+        updateWebViewContext(activity)
+    }
+
+    private fun updateWebViewContext(context: Context) {
+        val webViewContext = webView.context
+
+        if (webViewContext is MutableContextWrapper) {
+            webViewContext.baseContext = context
+        }
+    }
+
+    fun detachFrom(activity: ComponentActivity) {
+        updateWebViewContext(activity.applicationContext)
     }
 
     private fun detachCurrentLifecycleOwner() {

--- a/chat-sdk/src/main/java/com/livechatinc/chatsdk/src/presentation/LiveChatView.kt
+++ b/chat-sdk/src/main/java/com/livechatinc/chatsdk/src/presentation/LiveChatView.kt
@@ -75,19 +75,11 @@ class LiveChatView(
      * - file sharing
      * - showing external browser on link clicks
      * - setting the WebView background color
+     * - drop down menu support
      * Must be called in the Activity's `onCreate`
      */
     fun attachTo(activity: ComponentActivity) {
-        detachCurrentLifecycleOwner()
-
-        activityContextRef = WeakReference(activity)
-        currentLifecycleOwner = activity
-        activity.lifecycle.addObserver(this)
-
-        setupFileSharing(activity, activity.lifecycle)
-        setWebViewBackgroundColor(activity)
-
-        updateWebViewContext(activity)
+        attachTo(activity, activity)
     }
 
     /**
@@ -99,14 +91,18 @@ class LiveChatView(
         val activity = fragment.requireActivity() as? ComponentActivity
             ?: throw IllegalArgumentException("Fragment must be attached to a ComponentActivity")
 
+        attachTo(activity, fragment)
+    }
+
+    private fun attachTo(activity: ComponentActivity, lifecycleOwner: LifecycleOwner ){
         detachCurrentLifecycleOwner()
 
         activityContextRef = WeakReference(activity)
-        currentLifecycleOwner = fragment
-        fragment.lifecycle.addObserver(this)
+        currentLifecycleOwner = lifecycleOwner
+        lifecycleOwner.lifecycle.addObserver(this)
 
-        setupFileSharing(activity, fragment.lifecycle)
-        setWebViewBackgroundColor(fragment.requireContext())
+        setupFileSharing(activity, lifecycleOwner.lifecycle)
+        setWebViewBackgroundColor(activity)
 
         updateWebViewContext(activity)
     }

--- a/chat-sdk/src/main/java/com/livechatinc/chatsdk/src/presentation/LiveChatView.kt
+++ b/chat-sdk/src/main/java/com/livechatinc/chatsdk/src/presentation/LiveChatView.kt
@@ -94,7 +94,7 @@ class LiveChatView(
         attachTo(activity, fragment)
     }
 
-    private fun attachTo(activity: ComponentActivity, lifecycleOwner: LifecycleOwner ){
+    private fun attachTo(activity: ComponentActivity, lifecycleOwner: LifecycleOwner) {
         detachCurrentLifecycleOwner()
 
         activityContextRef = WeakReference(activity)

--- a/chat-sdk/src/main/res/layout/live_chat_widget_internal.xml
+++ b/chat-sdk/src/main/res/layout/live_chat_widget_internal.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<WebView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/live_chat_webview"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent" />

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,6 @@ org.gradle.jvmargs=-Xmx1536m
 android.useAndroidX=true
 android.enableJetifier=true
 android.enableR8.fullMode=true
-libraryVersion=3.0.2
+libraryVersion=3.0.3-rc1
 android.nonTransitiveRClass=true
 android.nonFinalResIds=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,6 @@ org.gradle.jvmargs=-Xmx1536m
 android.useAndroidX=true
 android.enableJetifier=true
 android.enableR8.fullMode=true
-libraryVersion=3.0.3-rc1
+libraryVersion=3.0.3
 android.nonTransitiveRClass=true
 android.nonFinalResIds=false


### PR DESCRIPTION
Fixes #112 

When using SDK in `LiveChatViewLifecycleScope.APP` mode, WebView is created with application context. This context is missing window token for webview to show dropdown menu options.

This fixes it by using MutableContextWrapper in `LiveChatViewLifecycleScope.APP` mode and swapping context when attached to an activity or a fragment.