### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @livechat/widget


### PR DESCRIPTION
## Add CODEOWNERS — automated PR

This PR was opened automatically to add a `.github/CODEOWNERS` file so that GitHub can auto-assign reviewers based on code ownership.

### What changed

A new `.github/CODEOWNERS` file was created:

```
* @livechat/widget
```

This means every file in the repository is owned by `@livechat/widget`. Members of that team will be auto-requested for review on every pull request.

### Review checklist

- [x] Confirm that `@livechat/widget` is the correct owning team for this repo
- [x] Add more specific path-based rules if needed (e.g. `src/api/ @livechat/other-team`)
- [x] **Merge into `master`**